### PR TITLE
Use `mdast-util-newline-to-break`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,8 @@
 /**
  * @typedef {import('mdast').Root} Root
- * @typedef {import('mdast').PhrasingContent} PhrasingContent
  */
 
-import {visit} from 'unist-util-visit'
-
-const find = /[\t ]*(?:\r?\n|\r)/g
+import {newlineToBreak} from 'mdast-util-newline-to-break'
 
 /**
  * Plugin to support hard breaks without needing spaces or escapes (turns enters
@@ -14,36 +11,5 @@ const find = /[\t ]*(?:\r?\n|\r)/g
  * @type {import('unified').Plugin<void[], Root>}
  */
 export default function remarkBreaks() {
-  return (tree) => {
-    visit(tree, 'text', (node, index, parent) => {
-      /** @type {PhrasingContent[]} */
-      const result = []
-      let start = 0
-
-      find.lastIndex = 0
-
-      let match = find.exec(node.value)
-
-      while (match) {
-        const position = match.index
-
-        if (start !== position) {
-          result.push({type: 'text', value: node.value.slice(start, position)})
-        }
-
-        result.push({type: 'break'})
-        start = position + match[0].length
-        match = find.exec(node.value)
-      }
-
-      if (result.length > 0 && parent && typeof index === 'number') {
-        if (start < node.value.length) {
-          result.push({type: 'text', value: node.value.slice(start)})
-        }
-
-        parent.children.splice(index, 1, ...result)
-        return index + result.length
-      }
-    })
-  }
+  return newlineToBreak
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@types/mdast": "^3.0.0",
     "unified": "^10.0.0",
-    "mdast-util-newline-to-break": "1.0.0"
+    "mdast-util-newline-to-break": "^1.0.0"
   },
   "devDependencies": {
     "@types/tape": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@types/mdast": "^3.0.0",
     "unified": "^10.0.0",
-    "unist-util-visit": "^4.0.0"
+    "mdast-util-newline-to-break": "1.0.0"
   },
   "devDependencies": {
     "@types/tape": "^4.0.0",


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Replace the transformer with `mdast-util-newline-to-break`.

Closes #9

<!--do not edit: pr-->
